### PR TITLE
Modify to work with current version of Turbine

### DIFF
--- a/python-sample-data-app/main.py
+++ b/python-sample-data-app/main.py
@@ -1,7 +1,6 @@
 import hashlib
 import typing as t
-from turbine import Turbine
-from turbine.runtime import Record
+from turbine.runtime import Record, Runtime
 
 
 def anonymize(records: t.List[Record]) -> t.List[Record]:
@@ -28,7 +27,7 @@ def anonymize(records: t.List[Record]) -> t.List[Record]:
 
 class App:
     @staticmethod
-    async def run(turbine: Turbine):
+    async def run(turbine: Runtime):
         try:
             # Get remote resource
             source = await turbine.resources("source_name")


### PR DESCRIPTION
I found I had to modify the main.py to work with the current version of turbine to avoid the following import error.

```ImportError: cannot import name 'Turbine' from 'turbine' (/Users/awmatheson/anaconda3/envs/meroxa/lib/python3.9/site-packages/turbine/__init__.py)```

I am currently building turbine-py from from the repo
