### PR TITLE
[bug] update GH action to use brew

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -29,6 +29,8 @@ jobs:
           python-version: '3.9'
           cache: 'pip'
           cache-dependency-path: '*.txt'
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
       - name: update pip
         run: |
           pip install -U wheel


### PR DESCRIPTION
The build image for github actions was updated to use an image of ubuntu that [does not have brew installed by default](https://github.com/actions/runner-images/issues/6283). This PR updates the action file for running tests to use the brew action rather than rely on `brew` being on the image itself. 