### PR TITLE
fix: Update notion connector example with new record format

### DIFF
--- a/notion-s3-python/main.py
+++ b/notion-s3-python/main.py
@@ -10,11 +10,13 @@ logging.basicConfig(level=logging.INFO)
 def character_count(records: RecordList) -> RecordList:
     for record in records:
         try:
-            plaintext = record.value["plaintext"]
-            metadata = record.value["metadata"]
+            payload = record.value["payload"]["after"]
+            metadata = payload["metadata"]
+
+            plaintext_len = len(payload.get('plaintext'))
 
             # Add the character count in the metadata JSON
-            metadata["characterCount"] = len(plaintext)
+            metadata.update({"characterCount": len(plaintext_len)})
         except Exception as e:
             print("Error occurred while parsing records: " + str(e))
     return records

--- a/notion-s3-python/main.py
+++ b/notion-s3-python/main.py
@@ -16,7 +16,7 @@ def character_count(records: RecordList) -> RecordList:
             plaintext_len = len(payload.get('plaintext'))
 
             # Add the character count in the metadata JSON
-            metadata.update({"characterCount": len(plaintext_len)})
+            metadata.update({"characterCount": plaintext_len})
         except Exception as e:
             print("Error occurred while parsing records: " + str(e))
     return records


### PR DESCRIPTION
The format of records coming from the Notion source connector has changed as part of the conduit 0.5 update. This change reflects that upstream change

Fixes: https://github.com/meroxa/turbine-py-examples/issues/31


